### PR TITLE
Fix Budget iOS app issue #1

### DIFF
--- a/Budget/Views/Main/BudgetSettingsView.swift
+++ b/Budget/Views/Main/BudgetSettingsView.swift
@@ -311,9 +311,6 @@ struct SyncSection: View {
                     }
 
                     Spacer()
-
-                    // Sync status indicator
-                    SyncStatusView(state: budgetManager.syncState)
                 }
 
                 // Sync now button


### PR DESCRIPTION
Removed the duplicate sync status icon from the Budget Settings view. The sync status is now only displayed in the top-left toolbar, eliminating the redundant icon that appeared in the Sync Section card.

Fixes #1