### PR TITLE
Resolve GitHub issue #3 for Budget iOS

### DIFF
--- a/Budget/Views/Main/MainAppView.swift
+++ b/Budget/Views/Main/MainAppView.swift
@@ -336,11 +336,6 @@ struct MainAppView: View {
                                 .foregroundColor(theme.colors.textPrimary)
                         }
                     }
-
-                    // Sync status indicator
-                    ToolbarItem(placement: .topBarLeading) {
-                        SyncStatusView(state: budgetManager.syncState)
-                    }
                 }
             }
         }


### PR DESCRIPTION
Fixed issue #3 by removing the second cloud sync icon (SyncStatusView) from the toolbar, keeping only the left SyncStatusIcon in the Budget Tab.