### PR TITLE
Fix Budget iOS GitHub Issue #5

### DIFF
--- a/Budget/DesignSystem/Components/DSCategoryGroupFilterSheet.swift
+++ b/Budget/DesignSystem/Components/DSCategoryGroupFilterSheet.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+struct DSCategoryGroupFilterSheet: View {
+    @ObservedObject var preferences: CategoryGroupPreferences
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.appTheme) private var theme
+    @State private var tempSelectedGroups: Set<CategoryGroup>
+
+    init(preferences: CategoryGroupPreferences) {
+        self.preferences = preferences
+        self._tempSelectedGroups = State(initialValue: preferences.selectedGroups)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                LazyVStack(spacing: DSSpacing.sm) {
+                    ForEach(CategoryGroup.allCases) { group in
+                        Button(action: {
+                            HapticManager.shared.buttonTap()
+                            toggleGroup(group)
+                        }) {
+                            HStack(spacing: DSSpacing.sm) {
+                                // Color indicator
+                                Circle()
+                                    .fill(group.color)
+                                    .frame(width: 12, height: 12)
+
+                                VStack(alignment: .leading, spacing: DSSpacing.xxs) {
+                                    DSText(group.displayName, font: .dsHeadline, color: theme.colors.textPrimary)
+                                    DSText(group.description, font: .dsCaption, color: theme.colors.textSecondary)
+                                        .lineLimit(2)
+                                }
+
+                                Spacer()
+
+                                // Checkbox
+                                Image(systemName: tempSelectedGroups.contains(group) ? "checkmark.circle.fill" : "circle")
+                                    .font(.dsHeadline)
+                                    .foregroundColor(tempSelectedGroups.contains(group) ? theme.colors.primary : theme.colors.textSecondary)
+                            }
+                            .padding(DSSpacing.md)
+                            .background(theme.colors.surface)
+                            .cornerRadius(12)
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                    }
+                }
+                .padding(.horizontal, DSSpacing.md)
+                .padding(.top, DSSpacing.md)
+            }
+            .background(theme.colors.background)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    DSText("Filter by Category Group", font: .dsHeadline, color: theme.colors.textPrimary)
+                }
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Image(systemName: "xmark")
+                        .font(.dsHeadline)
+                        .foregroundColor(theme.colors.textPrimary)
+                        .onTapGesture {
+                            dismiss()
+                        }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Image(systemName: "checkmark")
+                        .font(.dsHeadline)
+                        .foregroundColor(theme.colors.primary)
+                        .onTapGesture {
+                            HapticManager.shared.buttonTap()
+                            saveAndDismiss()
+                        }
+                }
+            }
+        }
+    }
+
+    private func toggleGroup(_ group: CategoryGroup) {
+        // Ensure at least one group remains selected
+        if tempSelectedGroups.contains(group) && tempSelectedGroups.count > 1 {
+            tempSelectedGroups.remove(group)
+        } else if !tempSelectedGroups.contains(group) {
+            tempSelectedGroups.insert(group)
+        } else {
+            // If trying to deselect the last group, show haptic feedback
+            HapticManager.shared.error()
+        }
+    }
+
+    private func saveAndDismiss() {
+        preferences.selectedGroups = tempSelectedGroups
+        dismiss()
+    }
+}
+
+#Preview {
+    @Previewable @StateObject var preferences = CategoryGroupPreferences()
+
+    DSCategoryGroupFilterSheet(preferences: preferences)
+}

--- a/Budget/Utilities/CategoryGroupPreferences.swift
+++ b/Budget/Utilities/CategoryGroupPreferences.swift
@@ -1,0 +1,52 @@
+//
+//  CategoryGroupPreferences.swift
+//  Budget
+//
+//  Manages user preferences for selected category groups in Budget tab
+//
+
+import Foundation
+
+@MainActor
+class CategoryGroupPreferences: ObservableObject {
+    private let userDefaultsKey = "selectedCategoryGroups"
+
+    @Published var selectedGroups: Set<CategoryGroup> {
+        didSet {
+            saveToUserDefaults()
+        }
+    }
+
+    init() {
+        // Load saved preferences or default to all groups
+        if let savedRawValues = UserDefaults.standard.array(forKey: userDefaultsKey) as? [String] {
+            let groups = savedRawValues.compactMap { CategoryGroup(rawValue: $0) }
+            self.selectedGroups = groups.isEmpty ? Set(CategoryGroup.allCases) : Set(groups)
+        } else {
+            // Default: all groups selected
+            self.selectedGroups = Set(CategoryGroup.allCases)
+        }
+    }
+
+    private func saveToUserDefaults() {
+        let rawValues = selectedGroups.map { $0.rawValue }
+        UserDefaults.standard.set(rawValues, forKey: userDefaultsKey)
+    }
+
+    func toggleGroup(_ group: CategoryGroup) {
+        // Ensure at least one group remains selected
+        if selectedGroups.contains(group) && selectedGroups.count > 1 {
+            selectedGroups.remove(group)
+        } else if !selectedGroups.contains(group) {
+            selectedGroups.insert(group)
+        }
+    }
+
+    var isAllGroupsSelected: Bool {
+        selectedGroups.count == CategoryGroup.allCases.count
+    }
+
+    var unselectedCount: Int {
+        CategoryGroup.allCases.count - selectedGroups.count
+    }
+}

--- a/Budget/ViewModels/BudgetManager.swift
+++ b/Budget/ViewModels/BudgetManager.swift
@@ -647,6 +647,44 @@ class BudgetManager: BudgetManagerProtocol {
         return min(1.0, spent / budgetAmount)
     }
 
+    // MARK: - Budget Analysis with Category Group Filtering
+
+    func totalBudgetAmount(excludingSavings: Bool, selectedGroups: Set<CategoryGroup>) -> Double {
+        let categories = budget.categories.filter { category in
+            let matchesGroup = selectedGroups.contains(category.categoryGroup)
+            let matchesType = !excludingSavings || category.categoryType == .expense
+            return matchesGroup && matchesType
+        }
+        return categories.reduce(0.0) { total, category in
+            total + (budget.categoryAmounts[category.id.uuidString] ?? 0)
+        }
+    }
+
+    func totalSpent(excludingSavings: Bool, selectedGroups: Set<CategoryGroup>) -> Double {
+        let categories = budget.categories.filter { category in
+            let matchesGroup = selectedGroups.contains(category.categoryGroup)
+            let matchesType = !excludingSavings || category.categoryType == .expense
+            return matchesGroup && matchesType
+        }
+        let categoryIds = Set(categories.map { $0.id })
+        return transactions
+            .filter { categoryIds.contains($0.categoryId) }
+            .reduce(0.0) { $0 + $1.amount }
+    }
+
+    func totalRemains(excludingSavings: Bool, selectedGroups: Set<CategoryGroup>) -> Double {
+        let spent = totalSpent(excludingSavings: excludingSavings, selectedGroups: selectedGroups)
+        let budgetAmount = totalBudgetAmount(excludingSavings: excludingSavings, selectedGroups: selectedGroups)
+        return max(0, budgetAmount - spent)
+    }
+
+    func spentPercentage(excludingSavings: Bool, selectedGroups: Set<CategoryGroup>) -> Double {
+        let budgetAmount = totalBudgetAmount(excludingSavings: excludingSavings, selectedGroups: selectedGroups)
+        guard budgetAmount > 0 else { return 0 }
+        let spent = totalSpent(excludingSavings: excludingSavings, selectedGroups: selectedGroups)
+        return min(1.0, spent / budgetAmount)
+    }
+
     // MARK: - Sub-Category Level Calculations
 
     func spentAmount(for subCategory: SubCategory) -> Double {

--- a/Budget/Views/Main/AnalysisComponents.swift
+++ b/Budget/Views/Main/AnalysisComponents.swift
@@ -548,28 +548,42 @@ struct DayOfWeekBar: View {
 struct OverviewHeroCard: View {
     let budgetManager: any BudgetManagerProtocol
     let excludeSavings: Bool
+    let selectedGroups: Set<CategoryGroup>?
     @Environment(\.appTheme) private var theme
     @State private var animatedSpentPercentage: Double = 0
 
-    init(budgetManager: any BudgetManagerProtocol, excludeSavings: Bool = false) {
+    init(budgetManager: any BudgetManagerProtocol, excludeSavings: Bool = false, selectedGroups: Set<CategoryGroup>? = nil) {
         self.budgetManager = budgetManager
         self.excludeSavings = excludeSavings
+        self.selectedGroups = selectedGroups
     }
 
     private var totalBudgetAmount: Double {
-        budgetManager.totalBudgetAmount(excludingSavings: excludeSavings)
+        if let selectedGroups = selectedGroups {
+            return budgetManager.totalBudgetAmount(excludingSavings: excludeSavings, selectedGroups: selectedGroups)
+        }
+        return budgetManager.totalBudgetAmount(excludingSavings: excludeSavings)
     }
 
     private var totalSpent: Double {
-        budgetManager.totalSpent(excludingSavings: excludeSavings)
+        if let selectedGroups = selectedGroups {
+            return budgetManager.totalSpent(excludingSavings: excludeSavings, selectedGroups: selectedGroups)
+        }
+        return budgetManager.totalSpent(excludingSavings: excludeSavings)
     }
 
     private var totalRemains: Double {
-        budgetManager.totalRemains(excludingSavings: excludeSavings)
+        if let selectedGroups = selectedGroups {
+            return budgetManager.totalRemains(excludingSavings: excludeSavings, selectedGroups: selectedGroups)
+        }
+        return budgetManager.totalRemains(excludingSavings: excludeSavings)
     }
 
     private var spentPercentage: Double {
-        budgetManager.spentPercentage(excludingSavings: excludeSavings)
+        if let selectedGroups = selectedGroups {
+            return budgetManager.spentPercentage(excludingSavings: excludeSavings, selectedGroups: selectedGroups)
+        }
+        return budgetManager.spentPercentage(excludingSavings: excludeSavings)
     }
 
     var body: some View {
@@ -666,11 +680,14 @@ struct OverviewHeroCard: View {
 struct CategoryGroupBarChart: View {
     let budgetManager: any BudgetManagerProtocol
     let excludeSavings: Bool
+    let selectedGroups: Set<CategoryGroup>?
     @Environment(\.appTheme) private var theme
     @State private var showText = false
 
     private var sortedGroups: [(CategoryGroup, Double)] {
-        CategoryGroup.allCases.compactMap { group in
+        let groupsToCheck = selectedGroups ?? Set(CategoryGroup.allCases)
+
+        return groupsToCheck.compactMap { group in
             let spent = budgetManager.spentAmount(for: group)
 
             // If excluding savings (expenses mode), include groups that have at least one savings category

--- a/Budget/Views/Main/MainAppView.swift
+++ b/Budget/Views/Main/MainAppView.swift
@@ -27,6 +27,8 @@ struct MainAppView: View {
     @State private var notificationManager = NotificationManager()
     @StateObject private var analysisViewModel: AnalysisViewModel
     @State private var expensesOnlyMode = true  // On by default
+    @StateObject private var categoryGroupPreferences = CategoryGroupPreferences()
+    @State private var showingCategoryGroupFilter = false
     @State private var showingCurrencySettings = false
     @State private var showingPeriodSettings = false
     @State private var showingCategorySettings = false
@@ -45,10 +47,11 @@ struct MainAppView: View {
     }
 
     private var sortedCategoryGroups: [CategoryGroup] {
-        // Get groups that have sub-categories with budgets (respect expenses-only mode)
+        // Get groups that have sub-categories with budgets (respect expenses-only mode and selected groups)
         let groupsWithBudget = CategoryGroup.allCases.filter { group in
             let allocated = budgetManager.allocatedAmount(for: group, excludingSavings: expensesOnlyMode)
-            return allocated > 0
+            let isSelected = categoryGroupPreferences.selectedGroups.contains(group)
+            return allocated > 0 && isSelected
         }
 
         // Sort by spending percentage (highest first)
@@ -134,6 +137,10 @@ struct MainAppView: View {
             }
             .fullScreenCover(isPresented: $showingBudgetEdit) {
                 BudgetEditView(budgetManager: budgetManager, onBudgetUpdated: {})
+            }
+            .sheet(isPresented: $showingCategoryGroupFilter) {
+                DSCategoryGroupFilterSheet(preferences: categoryGroupPreferences)
+                    .presentationDetents([.medium, .large])
             }
             .navigationDestination(isPresented: $showingHistoricalBudgets) {
                 HistoricalBudgetsView()
@@ -347,23 +354,43 @@ struct MainAppView: View {
             ScrollView {
                 VStack(spacing: DSSpacing.xl) {                    // Budget Section
                     VStack(spacing: DSSpacing.md) {
-                        // Section Header with Toggle
+                        // Section Header with Settings Icon
                         HStack {
                             DSText("Budget Overview", font: .dsSmallTitle, color: theme.colors.textPrimary)
                             Spacer()
 
-                            // Expenses Only Toggle
-                            HStack(spacing: DSSpacing.xs) {
-                                DSText("Expenses Only", font: .dsCaption, color: theme.colors.textSecondary)
-                                Toggle("", isOn: $expensesOnlyMode)
-                                    .labelsHidden()
-                                    .tint(theme.colors.primary)
+                            // Category Group Filter Settings Icon
+                            Button(action: {
+                                HapticManager.shared.buttonTap()
+                                showingCategoryGroupFilter = true
+                            }) {
+                                ZStack(alignment: .topTrailing) {
+                                    Image(systemName: "slider.horizontal.3")
+                                        .font(.dsHeadline)
+                                        .foregroundColor(theme.colors.textPrimary)
+                                        .padding(8)
+
+                                    // Badge indicator when not all groups are selected
+                                    if !categoryGroupPreferences.isAllGroupsSelected {
+                                        Text("\(categoryGroupPreferences.selectedGroups.count)")
+                                            .font(.system(size: 10, weight: .bold))
+                                            .foregroundColor(.white)
+                                            .frame(width: 16, height: 16)
+                                            .background(theme.colors.primary)
+                                            .clipShape(Circle())
+                                            .offset(x: 8, y: -4)
+                                    }
+                                }
                             }
                         }
                         .padding(.horizontal, DSSpacing.md)
 
                         // Budget Overview Hero Card
-                        OverviewHeroCard(budgetManager: budgetManager, excludeSavings: expensesOnlyMode)
+                        OverviewHeroCard(
+                            budgetManager: budgetManager,
+                            excludeSavings: expensesOnlyMode,
+                            selectedGroups: categoryGroupPreferences.selectedGroups
+                        )
                             .padding(.horizontal, DSSpacing.md)
                             .id(budgetManager.budget.id)
                             .transition(.opacity)
@@ -380,7 +407,11 @@ struct MainAppView: View {
                         .padding(.horizontal, DSSpacing.md)
 
                         // Single Chart - Group-based spending
-                        CategoryGroupBarChart(budgetManager: budgetManager, excludeSavings: expensesOnlyMode)
+                        CategoryGroupBarChart(
+                            budgetManager: budgetManager,
+                            excludeSavings: expensesOnlyMode,
+                            selectedGroups: categoryGroupPreferences.selectedGroups
+                        )
                     }
  
                     // All Transactions Link


### PR DESCRIPTION
Implements GitHub issue #5 - Users can now customize which category groups are displayed in the Budget tab and included in calculations.

Key changes:
- Replace "Expenses Only" toggle with a settings icon
- Add bottom sheet for selecting/deselecting category groups
- Show badge indicator on settings icon when not all groups selected
- Filter budget overview, charts, and category cards by selected groups
- Persist selections to UserDefaults
- Ensure at least one category group must remain selected
- "View All Transactions" remains unaffected by filtering

Components added:
- CategoryGroupPreferences: Manages selected groups with UserDefaults persistence
- DSCategoryGroupFilterSheet: Bottom sheet UI for multi-select of category groups

Components updated:
- BudgetManager: Added overloaded methods supporting selectedGroups parameter
- OverviewHeroCard: Accepts optional selectedGroups for filtered calculations
- CategoryGroupBarChart: Filters displayed groups based on selection
- MainAppView: Integrates preferences, settings icon, badge, and sheet presentation