### PR TITLE
Add Historical Budget UI with read-only transaction viewing

### DIFF
--- a/Budget/ViewModels/HistoricalBudgetManager.swift
+++ b/Budget/ViewModels/HistoricalBudgetManager.swift
@@ -1,0 +1,245 @@
+//
+//  HistoricalBudgetManager.swift
+//  Budget
+//
+//  Created for Historical Budget UI - Issue #7
+//  Read-only adapter for displaying historical budget data
+//
+
+import Foundation
+
+@MainActor
+@Observable
+class HistoricalBudgetManager: BudgetManagerProtocol {
+    // MARK: - Properties
+    let budget: Budget
+    private let _transactions: [Transaction]
+
+    // MARK: - Initialization
+    init(budget: Budget, transactions: [Transaction]) {
+        self.budget = budget
+        self._transactions = transactions
+    }
+
+    // MARK: - Computed Properties
+
+    var totalSpent: Double {
+        _transactions.reduce(0) { $0 + $1.amount }
+    }
+
+    var totalRemains: Double {
+        max(0, totalBudgetAmount(excludingSavings: false) - totalSpent)
+    }
+
+    var spentPercentage: Double {
+        let total = totalBudgetAmount(excludingSavings: false)
+        guard total > 0 else { return 0 }
+        return min(1.0, totalSpent / total)
+    }
+
+    // MARK: - Budget Analysis
+
+    func totalBudgetAmount(excludingSavings: Bool) -> Double {
+        let categories = excludingSavings
+            ? budget.categories.filter { $0.categoryType != .savings }
+            : budget.categories
+
+        return categories.reduce(0) { sum, category in
+            sum + (budget.categoryAmounts[category.id.uuidString] ?? 0)
+        }
+    }
+
+    func totalSpent(excludingSavings: Bool) -> Double {
+        if excludingSavings {
+            let savingsCategories = budget.categories.filter { $0.categoryType == .savings }
+            let savingsCategoryIds = Set(savingsCategories.map { $0.id })
+            return _transactions
+                .filter { !savingsCategoryIds.contains($0.categoryId) }
+                .reduce(0) { $0 + $1.amount }
+        } else {
+            return totalSpent
+        }
+    }
+
+    func totalRemains(excludingSavings: Bool) -> Double {
+        max(0, totalBudgetAmount(excludingSavings: excludingSavings) - totalSpent(excludingSavings: excludingSavings))
+    }
+
+    func spentPercentage(excludingSavings: Bool) -> Double {
+        let total = totalBudgetAmount(excludingSavings: excludingSavings)
+        guard total > 0 else { return 0 }
+        return min(1.0, totalSpent(excludingSavings: excludingSavings) / total)
+    }
+
+    // MARK: - Sub-Category Methods
+
+    func spentAmount(for subCategory: SubCategory) -> Double {
+        transactions(for: subCategory).reduce(0) { $0 + $1.amount }
+    }
+
+    func remainingAmount(for subCategory: SubCategory) -> Double {
+        let allocated = budget.categoryAmounts[subCategory.id.uuidString] ?? 0
+        return max(0, allocated - spentAmount(for: subCategory))
+    }
+
+    func spentPercentage(for subCategory: SubCategory) -> Double {
+        let allocated = budget.categoryAmounts[subCategory.id.uuidString] ?? 0
+        guard allocated > 0 else { return 0 }
+        return min(1.0, spentAmount(for: subCategory) / allocated)
+    }
+
+    func recentTransactions(for subCategory: SubCategory, limit: Int) -> [Transaction] {
+        Array(transactions(for: subCategory).prefix(limit))
+    }
+
+    func transactions(for subCategory: SubCategory) -> [Transaction] {
+        _transactions.filter { $0.categoryId == subCategory.id }
+            .sorted { $0.date > $1.date }
+    }
+
+    // MARK: - Category Group Methods
+
+    func spentAmount(for group: CategoryGroup, excludingSavings: Bool) -> Double {
+        transactions(for: group).reduce(0) { $0 + $1.amount }
+    }
+
+    func allocatedAmount(for group: CategoryGroup, excludingSavings: Bool) -> Double {
+        subCategories(for: group).reduce(0) { sum, category in
+            sum + (budget.categoryAmounts[category.id.uuidString] ?? 0)
+        }
+    }
+
+    func remainingAmount(for group: CategoryGroup, excludingSavings: Bool) -> Double {
+        max(0, allocatedAmount(for: group, excludingSavings: excludingSavings) - spentAmount(for: group, excludingSavings: excludingSavings))
+    }
+
+    func spentPercentage(for group: CategoryGroup, excludingSavings: Bool) -> Double {
+        let allocated = allocatedAmount(for: group, excludingSavings: excludingSavings)
+        guard allocated > 0 else { return 0 }
+        return min(1.0, spentAmount(for: group, excludingSavings: excludingSavings) / allocated)
+    }
+
+    func subCategories(for group: CategoryGroup) -> [SubCategory] {
+        budget.categories.filter { $0.categoryGroup == group }
+    }
+
+    func transactions(for group: CategoryGroup) -> [Transaction] {
+        let categoryIds = Set(subCategories(for: group).map { $0.id })
+        return _transactions.filter { categoryIds.contains($0.categoryId) }
+            .sorted { $0.date > $1.date }
+    }
+
+    func recentTransactions(for group: CategoryGroup, limit: Int) -> [Transaction] {
+        Array(transactions(for: group).prefix(limit))
+    }
+
+    // MARK: - Transaction Retrieval
+
+    func getAllTransactions() -> [Transaction] {
+        _transactions
+    }
+
+    func getAllTransactionsAcrossAllBudgets() -> [Transaction] {
+        // Historical budgets only return their own transactions
+        _transactions
+    }
+
+    // MARK: - Read-Only Stubs (Not Supported for Historical Budgets)
+
+    func addTransaction(_ transaction: Transaction) -> Bool {
+        print("⚠️ Cannot add transactions to historical budget")
+        return false
+    }
+
+    func updateTransaction(_ transaction: Transaction) -> Bool {
+        print("⚠️ Cannot update transactions in historical budget")
+        return false
+    }
+
+    func deleteTransaction(_ transaction: Transaction) -> Bool {
+        print("⚠️ Cannot delete transactions from historical budget")
+        return false
+    }
+
+    func deleteAllTransactions(for subCategory: SubCategory) -> Bool {
+        print("⚠️ Cannot delete transactions from historical budget")
+        return false
+    }
+
+    func undoLastTransaction() -> Bool {
+        print("⚠️ Cannot undo transactions in historical budget")
+        return false
+    }
+
+    func canUndo() -> Bool {
+        false
+    }
+
+    // MARK: - Budget Navigation Stubs (Not Supported)
+
+    func getAllBudgetsSorted() -> [Budget] {
+        [budget]
+    }
+
+    func getCurrentBudgetIndex() -> Int? {
+        0
+    }
+
+    func switchToPreviousBudget() -> Bool {
+        false
+    }
+
+    func switchToNextBudget() -> Bool {
+        false
+    }
+
+    func canSwitchToPrevious() -> Bool {
+        false
+    }
+
+    func canSwitchToNext() -> Bool {
+        false
+    }
+
+    func isViewingMostRecentBudget() -> Bool {
+        false
+    }
+
+    func switchToBudget(with id: UUID) -> Bool {
+        false
+    }
+
+    // MARK: - Budget Status (Historical budgets are always expired)
+
+    var isBudgetExpired: Bool {
+        true
+    }
+
+    var daysUntilBudgetEnd: Int {
+        0
+    }
+
+    func checkBudgetStatus() -> BudgetStatus {
+        .expired
+    }
+
+    func getNextBudgetPeriod() -> BudgetPeriod {
+        budget.period
+    }
+
+    func createNextPeriodBudget() async -> Bool {
+        print("⚠️ Cannot create next period from historical budget")
+        return false
+    }
+
+    // MARK: - Budget Updates (Not Supported)
+
+    func updateBudget(_ budget: Budget) -> Bool {
+        print("⚠️ Cannot update historical budget")
+        return false
+    }
+
+    func refreshFromSupabase() async {
+        print("⚠️ Cannot refresh historical budget from Supabase")
+    }
+}

--- a/Budget/Views/Main/AllTransactionsView.swift
+++ b/Budget/Views/Main/AllTransactionsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct AllTransactionsView: View {
     let budgetManager: any BudgetManagerProtocol
+    var isReadOnly: Bool = false  // Flag for historical budget read-only mode
     @Environment(\.dismiss) private var dismiss
     @Environment(\.appTheme) private var theme
     @State private var transactionToEdit: Transaction?
@@ -143,7 +144,7 @@ struct AllTransactionsView: View {
                                 date: date,
                                 transactions: transactions,
                                 budgetManager: budgetManager,
-                                onEditTransaction: { tx in
+                                onEditTransaction: isReadOnly ? nil : { tx in
                                     transactionToEdit = tx
                                 }
                             )
@@ -188,14 +189,17 @@ struct AllTransactionsView: View {
                 DefaultToolbarItem(kind: .search, placement: .bottomBar)
                 ToolbarSpacer(.flexible, placement: .bottomBar)
             }
-            ToolbarItem(placement: .bottomBar) {
-                Image(systemName: "plus.circle")
-                    .font(.dsHeadline)
-                    .foregroundColor(hasActiveFilters ? theme.colors.primary : theme.colors.textPrimary)
-                    .onTapGesture {
-                        HapticManager.shared.lightImpact()
-                        showAddTransaction = true
-                    }
+            // Only show add button if not in read-only mode
+            if !isReadOnly {
+                ToolbarItem(placement: .bottomBar) {
+                    Image(systemName: "plus.circle")
+                        .font(.dsHeadline)
+                        .foregroundColor(hasActiveFilters ? theme.colors.primary : theme.colors.textPrimary)
+                        .onTapGesture {
+                            HapticManager.shared.lightImpact()
+                            showAddTransaction = true
+                        }
+                }
             }
         }
         .searchable(
@@ -269,7 +273,7 @@ struct TransactionDateSection: View {
     let date: Date
     let transactions: [Transaction]
     let budgetManager: any BudgetManagerProtocol
-    let onEditTransaction: (Transaction) -> Void
+    let onEditTransaction: ((Transaction) -> Void)?  // Optional for read-only mode
     @Environment(\.appTheme) private var theme
     
     private var dateFormatter: DateFormatter {
@@ -312,9 +316,9 @@ struct TransactionDateSection: View {
                     TransactionRowView(
                         transaction: transaction,
                         budgetManager: budgetManager,
-                        onEditTransaction: {
-                            onEditTransaction(transaction)
-                        }
+                        onEditTransaction: onEditTransaction != nil ? {
+                            onEditTransaction?(transaction)
+                        } : nil
                     )
                     .padding(.horizontal, DSSpacing.md)
                 }
@@ -336,50 +340,55 @@ struct TransactionRowView: View {
 
 
     var body: some View {
-        Button(action: {
-            onEditTransaction?()
-        }) {
-            HStack(spacing: 0) {
-                // Color Border (like expandable card)
-                Rectangle()
-                    .fill(subCategory?.categoryGroup.color ?? theme.colors.textSecondary)
-                    .frame(width: 8)
-                    .cornerRadius(8, corners: [.topLeft, .bottomLeft])
+        let content = HStack(spacing: 0) {
+            // Color Border (like expandable card)
+            Rectangle()
+                .fill(subCategory?.categoryGroup.color ?? theme.colors.textSecondary)
+                .frame(width: 8)
+                .cornerRadius(8, corners: [.topLeft, .bottomLeft])
 
-                VStack(spacing: DSSpacing.xs) {
-                    // Transaction header
-                    HStack(alignment: .bottom) {
-                        VStack(alignment: .leading, spacing: DSSpacing.xxs) {
-                            DSText(transaction.name.isEmpty ? "Expense" : transaction.name, font: .dsHeadline, color: theme.colors.textPrimary)
-                                .lineLimit(1)
-                                .onAppear {
-                                    print("🔍 Displaying transaction: ID=\(transaction.id), Name='\(transaction.name)', isEmpty=\(transaction.name.isEmpty)")
-                                }
-                            HStack(spacing: DSSpacing.xxs) {
-                                DSText(subCategory?.name ?? "Unknown", font: .dsCaption, color: theme.colors.textSecondary)
-                                if let subCategory = subCategory {
-                                    DSText("•", font: .dsCaption, color: theme.colors.textSecondary)
-                                    DSText(subCategory.categoryGroup.displayName, font: .dsCaption, color: theme.colors.textSecondary)
-                                }
+            VStack(spacing: DSSpacing.xs) {
+                // Transaction header
+                HStack(alignment: .bottom) {
+                    VStack(alignment: .leading, spacing: DSSpacing.xxs) {
+                        DSText(transaction.name.isEmpty ? "Expense" : transaction.name, font: .dsHeadline, color: theme.colors.textPrimary)
+                            .lineLimit(1)
+                            .onAppear {
+                                print("🔍 Displaying transaction: ID=\(transaction.id), Name='\(transaction.name)', isEmpty=\(transaction.name.isEmpty)")
+                            }
+                        HStack(spacing: DSSpacing.xxs) {
+                            DSText(subCategory?.name ?? "Unknown", font: .dsCaption, color: theme.colors.textSecondary)
+                            if let subCategory = subCategory {
+                                DSText("•", font: .dsCaption, color: theme.colors.textSecondary)
+                                DSText(subCategory.categoryGroup.displayName, font: .dsCaption, color: theme.colors.textSecondary)
                             }
                         }
+                    }
 
-                        Spacer()
+                    Spacer()
 
-                        VStack(alignment: .trailing, spacing: DSSpacing.xxs) {
-                            DSText(String(format: "%.2f", transaction.amount), font: .dsBody, color: theme.colors.textPrimary)
-                                .fontWeight(.medium)
-                            DSText(budgetManager.budget.currency.code, font: .dsCaption, color: theme.colors.textSecondary)
-                        }
+                    VStack(alignment: .trailing, spacing: DSSpacing.xxs) {
+                        DSText(String(format: "%.2f", transaction.amount), font: .dsBody, color: theme.colors.textPrimary)
+                            .fontWeight(.medium)
+                        DSText(budgetManager.budget.currency.code, font: .dsCaption, color: theme.colors.textSecondary)
                     }
                 }
-                .padding(.horizontal, DSSpacing.md)
-                .padding(.vertical, DSSpacing.md)
             }
-            .background(theme.colors.surface)
-            .cornerRadius(8)
+            .padding(.horizontal, DSSpacing.md)
+            .padding(.vertical, DSSpacing.md)
         }
-        .buttonStyle(PlainButtonStyle())
+        .background(theme.colors.surface)
+        .cornerRadius(8)
+
+        // Conditionally wrap in button or return content directly
+        if let editAction = onEditTransaction {
+            Button(action: editAction) {
+                content
+            }
+            .buttonStyle(PlainButtonStyle())
+        } else {
+            content
+        }
     }
 }
 

--- a/Budget/Views/Main/HistoricalBudgetDetailView.swift
+++ b/Budget/Views/Main/HistoricalBudgetDetailView.swift
@@ -87,6 +87,13 @@ class HistoricalBudgetDetailViewModel {
         guard totalBudgetAmount > 0 else { return 0 }
         return min(1.0, totalSpent / totalBudgetAmount)
     }
+
+    /// Create a BudgetManager adapter for historical budget viewing
+    func createBudgetManager(for budget: SupabaseBudget) -> HistoricalBudgetManager {
+        let domainBudget = budget.toBudget(categories: categories)
+        let domainTransactions = transactions.map { $0.toTransaction() }
+        return HistoricalBudgetManager(budget: domainBudget, transactions: domainTransactions)
+    }
 }
 
 /// Read-only detail view for a historical budget
@@ -97,6 +104,7 @@ struct HistoricalBudgetDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel = HistoricalBudgetDetailViewModel()
     @State private var expandedCategories: Set<UUID> = []
+    @State private var showAllTransactions = false
 
     private var budgetPeriod: String {
         let formatter = DateFormatter()
@@ -170,6 +178,11 @@ struct HistoricalBudgetDetailView: View {
                             categoriesSection
                         }
 
+                        // View All Transactions section
+                        if !viewModel.transactions.isEmpty {
+                            viewAllTransactionsSection
+                        }
+
                         // Bottom spacing
                         Rectangle()
                             .fill(Color.clear)
@@ -194,6 +207,14 @@ struct HistoricalBudgetDetailView: View {
         }
         .task {
             await viewModel.fetchBudgetDetails(budgetId: budget.id)
+        }
+        .navigationDestination(isPresented: $showAllTransactions) {
+            if !viewModel.categories.isEmpty && !viewModel.transactions.isEmpty {
+                AllTransactionsView(
+                    budgetManager: viewModel.createBudgetManager(for: budget),
+                    isReadOnly: true
+                )
+            }
         }
     }
 
@@ -270,6 +291,47 @@ struct HistoricalBudgetDetailView: View {
                 }
                 .padding(.horizontal, DSSpacing.md)
                 .padding(.vertical, DSSpacing.md)
+            }
+            .padding(.horizontal, DSSpacing.md)
+        }
+    }
+
+    // MARK: - View All Transactions Section
+
+    private var viewAllTransactionsSection: some View {
+        VStack(spacing: DSSpacing.md) {
+            DSCard {
+                Button(action: {
+                    showAllTransactions = true
+                }) {
+                    HStack(spacing: DSSpacing.md) {
+                        // Icon
+                        Image(systemName: "list.bullet.rectangle")
+                            .font(.dsTitle)
+                            .foregroundColor(theme.colors.primary)
+                            .frame(width: 40, height: 40)
+                            .background(theme.colors.primary.opacity(0.1))
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                        // Info
+                        VStack(alignment: .leading, spacing: DSSpacing.xxs) {
+                            DSText("View All Transactions", font: .dsHeadline, color: theme.colors.textPrimary)
+                                .fontWeight(.medium)
+
+                            DSText("See all \(viewModel.transactions.count) transactions with search and filters", font: .dsCaption, color: theme.colors.textSecondary)
+                        }
+
+                        Spacer()
+
+                        // Chevron
+                        Image(systemName: "chevron.right")
+                            .font(.dsSubtitle)
+                            .foregroundColor(theme.colors.textSecondary)
+                    }
+                    .padding(.horizontal, DSSpacing.sm)
+                    .padding(.vertical, DSSpacing.sm)
+                }
+                .buttonStyle(PlainButtonStyle())
             }
             .padding(.horizontal, DSSpacing.md)
         }


### PR DESCRIPTION
Implements issue #7 - Historical Budget UI feature with the following changes:

1. **Read-only mode for AllTransactionsView**
   - Added `isReadOnly` flag to control transaction editing capabilities
   - When enabled, hides "Add Transaction" button
   - Disables transaction tap actions (no editing)
   - Preserves search and filter functionality

2. **HistoricalBudgetManager**
   - New adapter implementing BudgetManagerProtocol for historical budgets
   - Converts Supabase historical budget data to domain models
   - Provides read-only access to budget calculations and transactions
   - Stubs out mutation methods with appropriate warnings

3. **Enhanced HistoricalBudgetDetailView**
   - Added "View All Transactions" section with transaction count
   - Navigation to AllTransactionsView in read-only mode
   - Maintains existing budget overview and category sections
   - Info banner clearly indicates historical/read-only status

Features:
- Historical budgets display same layout as current Budget tab
- Budget overview card with summary, progress, and transaction count
- Expandable category cards showing transactions
- "View All Transactions" option with full search/filter capabilities
- Flag-based system ensures read-only enforcement across screens

All implementations follow Design System requirements using DS components.