### PR TITLE
Disable save button when no changes in category group filter

### DIFF
--- a/Budget/DesignSystem/Components/DSCategoryGroupFilterSheet.swift
+++ b/Budget/DesignSystem/Components/DSCategoryGroupFilterSheet.swift
@@ -11,6 +11,10 @@ struct DSCategoryGroupFilterSheet: View {
         self._tempSelectedGroups = State(initialValue: preferences.selectedGroups)
     }
 
+    private var hasChanges: Bool {
+        tempSelectedGroups != preferences.selectedGroups
+    }
+
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -64,13 +68,15 @@ struct DSCategoryGroupFilterSheet: View {
                         }
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Image(systemName: "checkmark")
-                        .font(.dsHeadline)
-                        .foregroundColor(theme.colors.primary)
-                        .onTapGesture {
-                            HapticManager.shared.buttonTap()
-                            saveAndDismiss()
-                        }
+                    Button(action: {
+                        HapticManager.shared.buttonTap()
+                        saveAndDismiss()
+                    }) {
+                        Image(systemName: "checkmark")
+                            .font(.dsHeadline)
+                            .foregroundColor(hasChanges ? theme.colors.primary : theme.colors.textSecondary.opacity(0.3))
+                    }
+                    .disabled(!hasChanges)
                 }
             }
         }


### PR DESCRIPTION
The checkmark icon in the filter sheet is now only active when there are changes from the previous selection. It appears disabled (faded) when the selection hasn't changed.

- Added hasChanges computed property to track selection changes
- Changed checkmark to Button with disabled state
- Visual feedback: primary color when active, faded when disabled